### PR TITLE
fix: the location of the legend for the example file

### DIFF
--- a/example.py
+++ b/example.py
@@ -118,7 +118,7 @@ plt.scatter([], [], edgecolors='r', facecolors='r', label='train -')
 plt.scatter([], [], edgecolors='g', facecolors='g', label='train +')
 plt.scatter([], [], edgecolors='r', facecolors='none', label='test -')
 plt.scatter([], [], edgecolors='g', facecolors='none', label='test +')
-plt.legend(loc='top right', ncol=2)
+plt.legend(loc='upper right', ncol=2)
 
 # Show & save the figure
 plt.title('pyRDF2Vec', fontsize=32)


### PR DESCRIPTION
This pull request fix the location string of the legend created by `matplotlib.pyplot` and at the same time allow the `example.py` to work again.

According to the `matplotlib` documentation, `loc='top right'` should be defined as `loc='upper right'`.

**Source:** https://matplotlib.org/3.3.0/api/_as_gen/matplotlib.pyplot.legend.html