### PR TITLE
refactor: fix imports for Python files

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,19 +1,19 @@
-import random
 import os
+import random
+import warnings
+
 import numpy as np
-import rdflib
-import pandas as pd
+
 import matplotlib.pyplot as plt
-
-from sklearn.svm import SVC
-from sklearn.metrics import confusion_matrix, accuracy_score
-from sklearn.manifold import TSNE
-
+import pandas as pd
+import rdflib
+from rdf2vec import RDF2VecTransformer
 from rdf2vec.converters import rdflib_to_kg
 from rdf2vec.walkers import RandomWalker
-from rdf2vec import RDF2VecTransformer
+from sklearn.manifold import TSNE
+from sklearn.metrics import accuracy_score, confusion_matrix
+from sklearn.svm import SVC
 
-import warnings
 warnings.filterwarnings('ignore')
 
 np.random.seed(42)

--- a/rdf2vec/_rdf2vec.py
+++ b/rdf2vec/_rdf2vec.py
@@ -1,13 +1,15 @@
-import rdflib
-import numpy as np
-from sklearn.utils.validation import check_is_fitted
-from gensim.models.word2vec import Word2Vec
-import tqdm
 import copy
-from rdf2vec.graph import Vertex
-from hashlib import md5
 import itertools
+from hashlib import md5
+
+import numpy as np
+
+import rdflib
+import tqdm
+from gensim.models.word2vec import Word2Vec
+from rdf2vec.graph import Vertex
 from rdf2vec.walkers import RandomWalker
+from sklearn.utils.validation import check_is_fitted
 
 
 class RDF2VecTransformer():

--- a/rdf2vec/converters.py
+++ b/rdf2vec/converters.py
@@ -1,5 +1,11 @@
+import urllib
+
+import requests
+
+import rdflib
 from rdf2vec.graph import KnowledgeGraph, Vertex
 from tqdm import tqdm
+
 
 def create_kg(triples, label_predicates):
     kg = KnowledgeGraph()
@@ -18,7 +24,6 @@ def create_kg(triples, label_predicates):
 
 def rdflib_to_kg(file, filetype=None, label_predicates=[]):
     """Convert a rdflib.Graph (located at file) to our KnowledgeGraph."""
-    import rdflib
 
     g = rdflib.Graph()
     if filetype is not None:
@@ -33,8 +38,6 @@ def rdflib_to_kg(file, filetype=None, label_predicates=[]):
 def endpoint_to_kg(endpoint_url="http://localhost:5820/db/query?query=", 
                    label_predicates=[]):
     """Generate KnowledgeGraph using SPARQL Endpoint."""
-    import urllib
-    import requests
 
     session = requests.Session()
     adapter = requests.adapters.HTTPAdapter(pool_connections=100, 

--- a/rdf2vec/graph.py
+++ b/rdf2vec/graph.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+
 class Vertex(object):
     vertex_counter = 0
     

--- a/rdf2vec/walkers/anonymous.py
+++ b/rdf2vec/walkers/anonymous.py
@@ -1,7 +1,10 @@
-from rdf2vec.walkers import RandomWalker
-from rdf2vec.graph import Vertex
-import numpy as np
 from hashlib import md5
+
+import numpy as np
+
+from rdf2vec.graph import Vertex
+from rdf2vec.walkers import RandomWalker
+
 
 class AnonymousWalker(RandomWalker):
     def __init__(self, depth, walks_per_graph):

--- a/rdf2vec/walkers/community.py
+++ b/rdf2vec/walkers/community.py
@@ -1,12 +1,15 @@
-from rdf2vec.walkers import Walker
-from rdf2vec.graph import Vertex
-from collections import defaultdict
-from hashlib import md5
-import networkx as nx
-import numpy as np
-import community
 import itertools
 import math
+from collections import defaultdict
+from hashlib import md5
+
+import numpy as np
+
+import community
+import networkx as nx
+from rdf2vec.graph import Vertex
+from rdf2vec.walkers import Walker
+
 
 def check_random_state(seed):
     return np.random

--- a/rdf2vec/walkers/halk.py
+++ b/rdf2vec/walkers/halk.py
@@ -1,8 +1,11 @@
 from collections import defaultdict
-from rdf2vec.walkers import RandomWalker
-from rdf2vec.graph import Vertex
-import numpy as np
 from hashlib import md5
+
+import numpy as np
+
+from rdf2vec.graph import Vertex
+from rdf2vec.walkers import RandomWalker
+
 
 class HalkWalker(RandomWalker):
     def __init__(self, depth, walks_per_graph, 

--- a/rdf2vec/walkers/ngrams.py
+++ b/rdf2vec/walkers/ngrams.py
@@ -1,8 +1,11 @@
-from rdf2vec.walkers import RandomWalker
-from rdf2vec.graph import Vertex
-import numpy as np
 import itertools
 from hashlib import md5
+
+import numpy as np
+
+from rdf2vec.graph import Vertex
+from rdf2vec.walkers import RandomWalker
+
 
 class NGramWalker(RandomWalker):
     def __init__(self, depth, walks_per_graph, n=3, wildcards=None):

--- a/rdf2vec/walkers/random.py
+++ b/rdf2vec/walkers/random.py
@@ -1,7 +1,9 @@
-from rdf2vec.walkers import Walker
-from rdf2vec.graph import Vertex
-import numpy as np
 from hashlib import md5
+
+import numpy as np
+
+from rdf2vec.graph import Vertex
+from rdf2vec.walkers import Walker
 
 
 class RandomWalker(Walker):

--- a/rdf2vec/walkers/walklets.py
+++ b/rdf2vec/walkers/walklets.py
@@ -1,7 +1,10 @@
-from rdf2vec.walkers import RandomWalker
-from rdf2vec.graph import Vertex
-import numpy as np
 from hashlib import md5
+
+import numpy as np
+
+from rdf2vec.graph import Vertex
+from rdf2vec.walkers import RandomWalker
+
 
 class WalkletWalker(RandomWalker):
     def __init__(self, depth, walks_per_graph):

--- a/rdf2vec/walkers/weisfeiler_lehman.py
+++ b/rdf2vec/walkers/weisfeiler_lehman.py
@@ -1,7 +1,8 @@
-from hashlib import md5
-from rdf2vec.walkers import RandomWalker
 from collections import defaultdict
+from hashlib import md5
+
 from rdf2vec.graph import Vertex
+from rdf2vec.walkers import RandomWalker
 
 
 class WeisfeilerLehmanWalker(RandomWalker):

--- a/rdf2vec/walkers/wildcard.py
+++ b/rdf2vec/walkers/wildcard.py
@@ -1,8 +1,11 @@
-from rdf2vec.walkers import RandomWalker
-from rdf2vec.graph import Vertex
-import numpy as np
 import itertools
 from hashlib import md5
+
+import numpy as np
+
+from rdf2vec.graph import Vertex
+from rdf2vec.walkers import RandomWalker
+
 
 class WildcardWalker(RandomWalker):
     def __init__(self, depth, walks_per_graph, wildcards=[1]):


### PR DESCRIPTION
This pull request will fix the import clauses according to the PEP conventions.

These conventions include:

- **Imports are always put at the top of the file**, just after any module comments and docstrings, and before module globals and constants.

- **Imports should be grouped** in the following order:
  1. Standard library imports.
  2. Related third party imports.
  3. Local application/library specific imports.

- **A blank line must be added between each group of imports**.

**Source**: https://www.python.org/dev/peps/pep-0008/