### PR TITLE
style: fix the global documentation

### DIFF
--- a/rdf2vec/_rdf2vec.py
+++ b/rdf2vec/_rdf2vec.py
@@ -1,17 +1,15 @@
-import rdflib
-import numpy as np
-from sklearn.utils.validation import check_is_fitted
-from gensim.models.word2vec import Word2Vec
-import tqdm
 import copy
-from rdf2vec.graph import Vertex
-from hashlib import md5
 import itertools
+from hashlib import md5
+
+import numpy as np
+
+import rdflib
+import tqdm
+from gensim.models.word2vec import Word2Vec
+from rdf2vec.graph import Vertex
 from rdf2vec.walkers import RandomWalker
-
-
-
-
+from sklearn.utils.validation import check_is_fitted
 
 
 class RDF2VecTransformer:

--- a/rdf2vec/_rdf2vec.py
+++ b/rdf2vec/_rdf2vec.py
@@ -13,7 +13,7 @@ from sklearn.utils.validation import check_is_fitted
 
 
 class RDF2VecTransformer:
-    """Transforms a knowledge graph into an embedding.
+    """Transforms nodes in a knowledge graph into an embedding.
 
     Attributes:
         vector_size (int): The dimension of the embeddings.
@@ -58,10 +58,6 @@ class RDF2VecTransformer:
     def fit(self, graph, instances):
         """Fits the embedding network based on provided instances.
 
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
-
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
                 The graph from which the neighborhoods are extracted for the
@@ -88,10 +84,6 @@ class RDF2VecTransformer:
     def transform(self, graph, instances):
         """Constructs a feature vector for the provided instances.
 
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
-
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph
                 The graph from which we will extract neighborhoods for the
@@ -115,10 +107,6 @@ class RDF2VecTransformer:
     def fit_transform(self, graph, instances):
         """Creates a Word2Vec model and generate embeddings for the provided
         instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph

--- a/rdf2vec/_rdf2vec.py
+++ b/rdf2vec/_rdf2vec.py
@@ -11,52 +11,29 @@ from rdf2vec.walkers import RandomWalker
 
 
 class RDF2VecTransformer():
-    """Project random walks or subtrees in graphs into embeddings, suited
-    for classification.
 
-    Parameters
-    ----------
-    vector_size: int (default: 500)
-        The dimension of the embeddings.
 
-    max_path_depth: int (default: 1)
-        The maximum number of hops to take in the knowledge graph. Due to the 
-        fact that we transform s -(p)-> o to s -> p -> o, this will be 
-        translated to `2 * max_path_depth` hops internally.
 
-    wl: bool (default: True)
-        Whether to use Weisfeiler-Lehman embeddings
 
-    wl_iterations: int (default: 4)
-        The number of Weisfeiler-Lehman iterations. Ignored if `wl` is False.
+    """Transforms a knowledge graph into an embedding.
 
-    walks_per_graph: int (default: infinity)
-        The maximum number of walks to extract from the neighborhood of
-        each instance.
-
-    n_jobs: int (default: 1)
-        gensim.models.Word2Vec parameter.
-
-    window: int (default: 5)
-        gensim.models.Word2Vec parameter.
-
-    sg: int (default: 1)
-        gensim.models.Word2Vec parameter.
-
-    max_iter: int (default: 10)
-        gensim.models.Word2Vec parameter.
-
-    negative: int (default: 25)
-        gensim.models.Word2Vec parameter.
-
-    min_count: int (default: 1)
-        gensim.models.Word2Vec parameter.
-
-    Attributes
-    ----------
-    model: gensim.models.Word2Vec
-        The fitted Word2Vec model. Embeddings can be accessed through
-        `self.model.wv.get_vector(str(instance))`.
+    Attributes:
+        vector_size (int): The dimension of the embeddings.
+            Defaults to 500.
+        walkers (Walker): The walking strategy.
+            Defaults to RandomWalker(2, float("inf)).
+        n_jobs (int): The number of threads to train the model.
+            Defaults to 1.
+        sg (int): The training algorithm. 1 for skip-gram; otherwise CBOW.
+            Defaults to 1.
+        max_iter (int): The number of iterations (epochs) over the corpus.
+            Defaults to 10.
+        negative (int): The negative sampling.
+            If > 0, the negative sampling will be used. Otherwise no negative
+            sampling is used.
+            Defaults to 25.
+        min_count (int): The total frequency to ignores all words.
+            Defaults to 1.
 
     """
     def __init__(self, vector_size=500, walkers=RandomWalker(2, float('inf')),
@@ -72,21 +49,21 @@ class RDF2VecTransformer():
         self.min_count = min_count
 
     def fit(self, graph, instances):
-        """Fit the embedding network based on provided instances.
-        
-        Parameters
-        ----------
-        graphs: graph.KnowledgeGraph
-            The graph from which we will extract neighborhoods for the
-            provided instances. You can create a `graph.KnowledgeGraph` object
-            from an `rdflib.Graph` object by using a converter method.
+        """Fits the embedding network based on provided instances.
 
-        instances: array-like
-            The instances for which an embedding will be created. It important
-            to note that the test instances should be passed to the fit method
-            as well. Due to RDF2Vec being unsupervised, there is no 
-            label leakage.
-        -------
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to create the embedding.
+                The test instances should be passed to the fit method as well.
+
+                Due to RDF2Vec being unsupervised, there is no label leakage.
+
         """
         self.walks_ = []
         for walker in self.walkers:
@@ -102,24 +79,24 @@ class RDF2VecTransformer():
                               min_count=self.min_count, seed=42)
 
     def transform(self, graph, instances):
-        """Construct a feature vector for the provided instances.
+        """Constructs a feature vector for the provided instances.
 
-        Parameters
-        ----------
-        graphs: graph.KnowledgeGraph
-            The graph from which we will extract neighborhoods for the
-            provided instances. You can create a `graph.KnowledgeGraph` object
-            from an `rdflib.Graph` object by using a converter method.
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
 
-        instances: array-like
-            The instances for which an embedding will be created. These 
-            instances must have been passed to the fit method as well,
-            or their embedding will not exist in the model vocabulary.
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph
+                The graph from which we will extract neighborhoods for the
+                provided instances.
+            instances (array-like): The instances to create the embedding.
+                The test instances should be passed to the fit method as well.
 
-        Returns
-        -------
-        embeddings: array-like
-            The embeddings of the provided instances.
+                Due to RDF2Vec being unsupervised, there is no label leakage.
+
+        Returns:
+            array-like: The embeddings of the provided instances.
+
         """
         check_is_fitted(self, ['model_'])
 
@@ -129,23 +106,25 @@ class RDF2VecTransformer():
         return feature_vectors
 
     def fit_transform(self, graph, instances):
-        """First apply fit to create a Word2Vec model and then generate
-        embeddings for the provided instances.
+        """Creates a Word2Vec model and generate embeddings for the provided
+        instances.
 
-        Parameters
-        ----------
-        graphs: graph.KnowledgeGraph
-            The graph from which we will extract neighborhoods for the
-            provided instances. You can create a `graph.KnowledgeGraph` object
-            from an `rdflib.Graph` object by using a converter method.
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
 
-        instances: array-like
-            The instances for which an embedding will be created. 
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph
+                The graph from which we will extract neighborhoods for the
+                provided instances.
+            instances (array-like): The instances to create the embedding.
+                The test instances should be passed to the fit method as well.
 
-        Returns
-        -------
-        embeddings: array-like
-            The embeddings of the provided instances.
+                Due to RDF2Vec being unsupervised, there is no label leakage.
+
+        Returns:
+            array-like: The embeddings of the provided instances.
+
         """
         self.fit(graph, instances)
         return self.transform(graph, instances)

--- a/rdf2vec/_rdf2vec.py
+++ b/rdf2vec/_rdf2vec.py
@@ -10,11 +10,11 @@ import itertools
 from rdf2vec.walkers import RandomWalker
 
 
-class RDF2VecTransformer():
 
 
 
 
+class RDF2VecTransformer:
     """Transforms a knowledge graph into an embedding.
 
     Attributes:
@@ -36,9 +36,18 @@ class RDF2VecTransformer():
             Defaults to 1.
 
     """
-    def __init__(self, vector_size=500, walkers=RandomWalker(2, float('inf')),
-                 n_jobs=1, window=5, sg=1, max_iter=10, negative=25, 
-                 min_count=1):
+
+    def __init__(
+        self,
+        vector_size=500,
+        walkers=RandomWalker(2, float("inf")),
+        n_jobs=1,
+        window=5,
+        sg=1,
+        max_iter=10,
+        negative=25,
+        min_count=1,
+    ):
         self.vector_size = vector_size
         self.walkers = walkers
         self.n_jobs = n_jobs

--- a/rdf2vec/converters.py
+++ b/rdf2vec/converters.py
@@ -2,6 +2,16 @@ from rdf2vec.graph import KnowledgeGraph, Vertex
 from tqdm import tqdm
 
 def create_kg(triples, label_predicates):
+    """Creates a knowledge graph according to triples and predicates label.
+
+    Args:
+        triples (list): The triples.
+        label_predicates (list): The predicates label.
+
+    Returns:
+        graph.KnowledgeGraph: The knowledge graph.
+
+    """
     kg = KnowledgeGraph()
     for (s, p, o) in tqdm(triples):
         if p not in label_predicates:
@@ -17,7 +27,19 @@ def create_kg(triples, label_predicates):
 
 
 def rdflib_to_kg(file, filetype=None, label_predicates=[]):
-    """Convert a rdflib.Graph (located at file) to our KnowledgeGraph."""
+    """Converts a rdflib.Graph to a knowledge graph.
+
+    Args:
+        file (file-like): The file that contains the rdflib.Graph
+        filetype (string): The format of the knowledge graph.
+            Defaults to None.
+        label_predicates (list): The predicates label.
+            Defaults to [].
+
+    Returns:
+        graph.KnowledgeGraph: The knowledge graph.
+
+    """
     import rdflib
 
     g = rdflib.Graph()
@@ -32,7 +54,17 @@ def rdflib_to_kg(file, filetype=None, label_predicates=[]):
 
 def endpoint_to_kg(endpoint_url="http://localhost:5820/db/query?query=", 
                    label_predicates=[]):
-    """Generate KnowledgeGraph using SPARQL Endpoint."""
+    """Generates a knowledge graph using a SPARQL endpoint.
+
+    endpoint_url (string): The SPARQL endpoint.
+        Defaults to http://localhost:5820/db/query?query=
+    label_predicates (list): The predicates label.
+        Defaults to [].
+
+    Returns:
+        graph.KnowledgeGraph: The knowledge graph.
+
+    """
     import urllib
     import requests
 

--- a/rdf2vec/converters.py
+++ b/rdf2vec/converters.py
@@ -26,11 +26,11 @@ def create_kg(triples, label_predicates):
     return kg
 
 
-def rdflib_to_kg(file, filetype=None, label_predicates=[]):
+def rdflib_to_kg(file_name, filetype=None, label_predicates=[]):
     """Converts a rdflib.Graph to a knowledge graph.
 
     Args:
-        file (file-like): The file that contains the rdflib.Graph
+        file_name (str): The file name that contains the rdflib.Graph.
         filetype (string): The format of the knowledge graph.
             Defaults to None.
         label_predicates (list): The predicates label.
@@ -44,9 +44,9 @@ def rdflib_to_kg(file, filetype=None, label_predicates=[]):
 
     g = rdflib.Graph()
     if filetype is not None:
-        g.parse(file, format=filetype)
+        g.parse(file_name, format=filetype)
     else:
-        g.parse(file)
+        g.parse(file_name)
 
     label_predicates = [rdflib.term.URIRef(x) for x in label_predicates]
     return create_kg(g, label_predicates)

--- a/rdf2vec/converters.py
+++ b/rdf2vec/converters.py
@@ -5,8 +5,10 @@ def create_kg(triples, label_predicates):
     """Creates a knowledge graph according to triples and predicates label.
 
     Args:
-        triples (list): The triples.
-        label_predicates (list): The predicates label.
+        triples (list): The triples where each item in this list must be an
+            iterable (e.g., tuple, list) of three elements.
+        label_predicates (list): The URI's of the predicates that have to be
+            excluded from the graph to avoid leakage.
 
     Returns:
         graph.KnowledgeGraph: The knowledge graph.

--- a/rdf2vec/graph.py
+++ b/rdf2vec/graph.py
@@ -1,6 +1,19 @@
 from collections import defaultdict
 
 class Vertex(object):
+    """Represents a vertex in a knowledge graph.
+
+    Attributes:
+        name (string): The vertex name.
+        predicate (bool): The predicate.
+            Defaults to False.
+        _from: The previous vertex.
+            Defaults to None.
+        _to: The next vertex.
+            Defaults to None.
+
+    """
+
     vertex_counter = 0
     
     def __init__(self, name, predicate=False, _from=None, _to=None):
@@ -13,53 +26,115 @@ class Vertex(object):
         Vertex.vertex_counter += 1
         
     def __eq__(self, other):
-        if other is None: 
+        """Defines behavior for the equality operator, ==.
+
+        Args:
+            other (Vertex): The other vertex to test the equality.
+
+        Returns:
+            bool: True if the hash of the vertices are equal. False otherwise.
+
+        """
+        if other is None:
             return False
         return self.__hash__() == other.__hash__()
     
     def __hash__(self):
+        """Defines behavior for when hash() is called on a vertex.
+
+        Returns:
+            int: The identifier and name of the vertex, as well as its previous
+                and next neighbor if the vertex has a predicate. The hash of
+                the name of the vertex otherwise.
+
+        """
         if self.predicate:
             return hash((self.id, self._from, self._to, self.name))
         else:
             return hash(self.name)
 
     def __lt__(self, other):
+        """Defines behavior for the less-than operator, <.
+
+        Args:
+            other (Vertex): The other vertex to test the equality.
+
+        Returns:
+            bool: True if the name of the first vertex is less than equal to the
+                name of the other vertex.
+
+        """
         return self.name < other.name
 
 
 class KnowledgeGraph(object):
+    """Represents a knowledge graph. """
+
     def __init__(self):
         self._vertices = set()
         self._transition_matrix = defaultdict(set)
         self._inv_transition_matrix = defaultdict(set)
         
     def add_vertex(self, vertex):
-        """Add a vertex to the Knowledge Graph."""
+        """Adds a vertex to the knowledge graph.
+
+        Args:
+            vertex (Vertex): The vertex
+
+        """
         if vertex.predicate:
             self._vertices.add(vertex)
         else:
             self._vertices.add(vertex)
 
     def add_edge(self, v1, v2):
-        """Add a uni-directional edge."""
+        """Adds a uni-directional edge.
+
+        Args:
+            v1 (string): The name of the first vertex.
+            v2 (string): The name of the second vertex.
+
+        """
         self._transition_matrix[v1].add(v2)
         self._inv_transition_matrix[v2].add(v1)
         
     def remove_edge(self, v1, v2):
-        """Remove the edge v1 -> v2 if present."""
+        """Removes the edge (v1 -> v2) if present.
+
+        Args:
+            v1 (string): The name of the first vertex.
+            v2 (string): The name of the second vertex.
+
+        """
         if v2 in self._transition_matrix[v1]:
             self._transition_matrix[v1].remove(v2)
 
     def get_neighbors(self, vertex):
-        """Get all the neighbors of vertex (vertex -> neighbor)."""
+        """Gets the neighbors of a vertex.
+
+        Args:
+            vertex (Vertex): The vertex.
+
+        Returns:
+            array-like: The neighbors of a vertex.
+
+        """
         return self._transition_matrix[vertex]
 
     def get_inv_neighbors(self, vertex):
-        """Get all the neighbors of vertex (vertex -> neighbor)."""
+        """Gets the reverse neighbors of a vertex.
+
+        Args:
+            vertex (Vertex): The vertex.
+
+        Returns:
+            array-like: The reverse neighbors of a vertex.
+
+        """
         return self._inv_transition_matrix[vertex]
     
     def visualise(self):
-        """Visualise the graph using networkx & matplotlib."""
+        """Visualises the knowledge graph."""
         import matplotlib.pyplot as plt
         import networkx as nx
         nx_graph = nx.DiGraph()

--- a/rdf2vec/walkers/anonymous.py
+++ b/rdf2vec/walkers/anonymous.py
@@ -9,6 +9,7 @@ class AnonymousWalker(RandomWalker):
     Attributes:
         depth (int): The depth per entity.
         walks_per_graph (float): The maximum number of walks per entity.
+
     """
 
     def __init__(self, depth, walks_per_graph):

--- a/rdf2vec/walkers/anonymous.py
+++ b/rdf2vec/walkers/anonymous.py
@@ -4,7 +4,7 @@ import numpy as np
 from hashlib import md5
 
 class AnonymousWalker(RandomWalker):
-    """Defines the anonymous walker of the walking strategy.
+    """Defines the anonymous walking strategy.
 
     Attributes:
         depth (int): The depth per entity.
@@ -16,12 +16,8 @@ class AnonymousWalker(RandomWalker):
         super(AnonymousWalker, self).__init__(depth, walks_per_graph)
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -30,7 +26,9 @@ class AnonymousWalker(RandomWalker):
             instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         canonical_walks = set()

--- a/rdf2vec/walkers/anonymous.py
+++ b/rdf2vec/walkers/anonymous.py
@@ -4,10 +4,34 @@ import numpy as np
 from hashlib import md5
 
 class AnonymousWalker(RandomWalker):
+    """Defines the anonymous walker of the walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+    """
+
     def __init__(self, depth, walks_per_graph):
         super(AnonymousWalker, self).__init__(depth, walks_per_graph)
 
     def extract(self, graph, instances):
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         canonical_walks = set()
         for instance in instances:
             walks = self.extract_random_walks(graph, Vertex(str(instance)))

--- a/rdf2vec/walkers/community.py
+++ b/rdf2vec/walkers/community.py
@@ -22,7 +22,7 @@ def sample_from_iterable(x):
 np.random.permutation = lambda x: next(itertools.permutations(x))#sample_from_iterable
 
 class CommunityWalker(Walker):
-    """Defines the community walker of the walking strategy.
+    """Defines the community walking strategy.
 
     Attributes:
         depth (int): The depth per entity.
@@ -135,12 +135,8 @@ class CommunityWalker(Walker):
         return list(walks)
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -149,7 +145,9 @@ class CommunityWalker(Walker):
             instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         self._community_detection(graph)

--- a/rdf2vec/walkers/community.py
+++ b/rdf2vec/walkers/community.py
@@ -22,13 +22,35 @@ def sample_from_iterable(x):
 np.random.permutation = lambda x: next(itertools.permutations(x))#sample_from_iterable
 
 class CommunityWalker(Walker):
+    """Defines the community walker of the walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+        hop_prob (float): The probability to hop.
+            Defaults to 0.1.
+        resolution (int): The resolution.
+            Defaults to 1.
+
+    """
     def __init__(self, depth, walks_per_graph, hop_prob=0.1, resolution=1):
         super(CommunityWalker, self).__init__(depth, walks_per_graph)
         self.hop_prob = hop_prob
         self.resolution = resolution
 
     def _community_detection(self, graph):
-        # Convert our graph to a networkX graph
+        """Converts the knowledge graph to a networkX graph.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+
+        """
         nx_graph = nx.Graph()
 
         for v in graph._vertices:
@@ -61,7 +83,22 @@ class CommunityWalker(Walker):
             self.labels_per_community[self.communities[node]].append(node)
 
     def extract_random_community_walks(self, graph, root):
-        """Extract random walks of depth - 1 hops rooted in root."""
+        """Extracts random walks of depth - 1 hops rooted in root.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            root (Vertex): The root.
+
+        Returns:
+            numpy.array: The array of the walks.
+
+        """
         # Initialize one walk of length 1 (the root)
 
         walks = {(root,)}
@@ -98,6 +135,23 @@ class CommunityWalker(Walker):
         return list(walks)
 
     def extract(self, graph, instances):
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         self._community_detection(graph)
         canonical_walks = set()
         for instance in instances:

--- a/rdf2vec/walkers/halk.py
+++ b/rdf2vec/walkers/halk.py
@@ -5,7 +5,7 @@ import numpy as np
 from hashlib import md5
 
 class HalkWalker(RandomWalker):
-    """Defines the halk walker of the walking strategy.
+    """Defines the halk walking strategy.
 
     Attributes:
         depth (int): The depth per entity.
@@ -19,12 +19,8 @@ class HalkWalker(RandomWalker):
         # self.lb_freq_threshold = lb_freq_threshold
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -33,7 +29,9 @@ class HalkWalker(RandomWalker):
             instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         canonical_walks = set()

--- a/rdf2vec/walkers/halk.py
+++ b/rdf2vec/walkers/halk.py
@@ -5,13 +5,37 @@ import numpy as np
 from hashlib import md5
 
 class HalkWalker(RandomWalker):
-    def __init__(self, depth, walks_per_graph, 
-                 freq_thresholds=[0.001]):
+    """Defines the halk walker of the walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+
+    """
+
+    def __init__(self, depth, walks_per_graph, freq_thresholds=[0.001]):
         super(HalkWalker, self).__init__(depth, walks_per_graph)
         self.freq_thresholds = freq_thresholds
         # self.lb_freq_threshold = lb_freq_threshold
 
     def extract(self, graph, instances):
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         canonical_walks = set()
         all_walks=[]
         for instance in instances:

--- a/rdf2vec/walkers/halk.py
+++ b/rdf2vec/walkers/halk.py
@@ -5,7 +5,7 @@ import numpy as np
 from hashlib import md5
 
 class HalkWalker(RandomWalker):
-    """Defines the halk walking strategy.
+    """Defines the Hierarchical Walking (HALK) strategy.
 
     Attributes:
         depth (int): The depth per entity.

--- a/rdf2vec/walkers/ngrams.py
+++ b/rdf2vec/walkers/ngrams.py
@@ -5,6 +5,18 @@ import itertools
 from hashlib import md5
 
 class NGramWalker(RandomWalker):
+    """Defines the N-Grams walker of the walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+        n (int): The number of grams.
+            Defaults to 3.
+        wildcards (list): the wild cards.
+            Defaults to None.
+
+    """
+
     def __init__(self, depth, walks_per_graph, n=3, wildcards=None):
         super(NGramWalker, self).__init__(depth, walks_per_graph)
         self.n = n
@@ -12,6 +24,15 @@ class NGramWalker(RandomWalker):
         self.n_gram_map = {}
 
     def _take_n_grams(self, walk):
+        """Takes the N-Grams.
+
+        Args:
+            walk (list): The walk.
+
+        Returns:
+            list: The N-Grams.
+
+        """
         n_gram_walk = []
         for i, hop in enumerate(walk):
             if i == 0 or i % 2 == 1 or i < self.n:
@@ -26,6 +47,23 @@ class NGramWalker(RandomWalker):
         return n_gram_walk
 
     def extract(self, graph, instances):
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         canonical_walks = set()
         for instance in instances:
             walks = self.extract_random_walks(graph, Vertex(str(instance)))

--- a/rdf2vec/walkers/ngrams.py
+++ b/rdf2vec/walkers/ngrams.py
@@ -5,7 +5,7 @@ import itertools
 from hashlib import md5
 
 class NGramWalker(RandomWalker):
-    """Defines the N-Grams walker of the walking strategy.
+    """Defines the N-Grams walking strategy.
 
     Attributes:
         depth (int): The depth per entity.
@@ -47,12 +47,8 @@ class NGramWalker(RandomWalker):
         return n_gram_walk
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -61,7 +57,9 @@ class NGramWalker(RandomWalker):
             instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         canonical_walks = set()

--- a/rdf2vec/walkers/random.py
+++ b/rdf2vec/walkers/random.py
@@ -5,7 +5,7 @@ from hashlib import md5
 
 
 class RandomWalker(Walker):
-    """Defines the random walker of the walking strategy.
+    """Defines the random walking strategy.
 
     Attributes:
         depth (int): The depth per entity.
@@ -18,10 +18,6 @@ class RandomWalker(Walker):
 
     def extract_random_walks(self, graph, root):
         """Extracts random walks of depth - 1 hops rooted in root.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -63,12 +59,8 @@ class RandomWalker(Walker):
         return list(walks)
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -77,7 +69,9 @@ class RandomWalker(Walker):
             instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         canonical_walks = set()

--- a/rdf2vec/walkers/random.py
+++ b/rdf2vec/walkers/random.py
@@ -5,11 +5,34 @@ from hashlib import md5
 
 
 class RandomWalker(Walker):
+    """Defines the random walker of the walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+
+    """
+
     def __init__(self, depth, walks_per_graph):
         super(RandomWalker, self).__init__(depth, walks_per_graph)
 
     def extract_random_walks(self, graph, root):
-        """Extract random walks of depth - 1 hops rooted in root."""
+        """Extracts random walks of depth - 1 hops rooted in root.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            root (Vertex): The root.
+
+        Returns:
+            numpy.array: The array of the walks.
+
+        """
         # Initialize one walk of length 1 (the root)
         walks = {(root,)}
 
@@ -40,6 +63,23 @@ class RandomWalker(Walker):
         return list(walks)
 
     def extract(self, graph, instances):
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         canonical_walks = set()
         for instance in instances:
             walks = self.extract_random_walks(graph, Vertex(str(instance)))

--- a/rdf2vec/walkers/walker.py
+++ b/rdf2vec/walkers/walker.py
@@ -15,16 +15,16 @@ class Walker():
         """Prints the walks of a knowledge graph.
 
         Note:
-                You can create a `graph.KnowledgeGraph` object from an
-                `rdflib.Graph` object by using a converter method.
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
 
         Args:
-                graph (graph.KnowledgeGraph): The knowledge graph.
-                The graph from which the neighborhoods are extracted for the
-                provided instances.
-                instances (array-like): The instances to extract the knowledge
-            graph.
-                file_name (str): The filename that contains the rdflib.Graph
+            graph (graph.KnowledgeGraph): The knowledge graph.
+            The graph from which the neighborhoods are extracted for the
+            provided instances.
+            instances (array-like): The instances to extract the knowledge
+                graph.
+            file_name (str): The filename that contains the rdflib.Graph
 
         """
         walks = self.extract(graph, instances)
@@ -49,22 +49,20 @@ class Walker():
 
     def extract(self, graph, instances):
         """Extracts a knowledge graph and transform it into a 2D vector, based
-            on provided instances.
+        on provided instances.
 
         Note:
-                You can create a `graph.KnowledgeGraph` object from an
-                `rdflib.Graph` object by using a converter method.
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
 
         Args:
-                graph (graph.KnowledgeGraph): The knowledge graph.
+            graph (graph.KnowledgeGraph): The knowledge graph.
                 The graph from which the neighborhoods are extracted for the
                 provided instances.
-                instances (array-like): The instances to extract the knowledge
-                    graph.
+            instances (array-like): The instances to extract the knowledge graph.
 
-        Raises:
-                NotImplementedError: This method must be implemented by the by
-                    the inherited subclasses.
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
 
         """
         raise NotImplementedError("This must be implemented!")

--- a/rdf2vec/walkers/walker.py
+++ b/rdf2vec/walkers/walker.py
@@ -1,5 +1,5 @@
 class Walker:
-    """Base class for the walking strategy.
+    """Base class for the walking strategies.
 
     Attributes:
         depth (int): The depth per entity.

--- a/rdf2vec/walkers/walker.py
+++ b/rdf2vec/walkers/walker.py
@@ -1,3 +1,4 @@
+class Walker:
     """Base class for the walking strategy.
 
     Attributes:
@@ -6,7 +7,6 @@
 
     """
 
-class Walker():
     def __init__(self, depth, walks_per_graph):
         self.depth = depth
         self.walks_per_graph = walks_per_graph

--- a/rdf2vec/walkers/walker.py
+++ b/rdf2vec/walkers/walker.py
@@ -1,4 +1,10 @@
+    """Base class for the walking strategy.
 
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+
+    """
 
 class Walker():
     def __init__(self, depth, walks_per_graph):
@@ -6,6 +12,21 @@ class Walker():
         self.walks_per_graph = walks_per_graph
 
     def print_walks(self, graph, instances, file_name):
+        """Prints the walks of a knowledge graph.
+
+        Note:
+                You can create a `graph.KnowledgeGraph` object from an
+                `rdflib.Graph` object by using a converter method.
+
+        Args:
+                graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+                instances (array-like): The instances to extract the knowledge
+            graph.
+                file_name (str): The filename that contains the rdflib.Graph
+
+        """
         walks = self.extract(graph, instances)
         walk_strs = []
         for walk_nr, walk in enumerate(walks):
@@ -27,4 +48,23 @@ class Walker():
                 myfile.write('\n\n')
 
     def extract(self, graph, instances):
-        raise NotImplementedError('This must be implemented!')
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+            on provided instances.
+
+        Note:
+                You can create a `graph.KnowledgeGraph` object from an
+                `rdflib.Graph` object by using a converter method.
+
+        Args:
+                graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+                instances (array-like): The instances to extract the knowledge
+                    graph.
+
+        Raises:
+                NotImplementedError: This method must be implemented by the by
+                    the inherited subclasses.
+
+        """
+        raise NotImplementedError("This must be implemented!")

--- a/rdf2vec/walkers/walker.py
+++ b/rdf2vec/walkers/walker.py
@@ -14,10 +14,6 @@ class Walker:
     def print_walks(self, graph, instances, file_name):
         """Prints the walks of a knowledge graph.
 
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
-
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
             The graph from which the neighborhoods are extracted for the
@@ -48,12 +44,8 @@ class Walker:
                 myfile.write('\n\n')
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -62,7 +54,9 @@ class Walker:
             instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         raise NotImplementedError("This must be implemented!")

--- a/rdf2vec/walkers/walklets.py
+++ b/rdf2vec/walkers/walklets.py
@@ -4,10 +4,35 @@ import numpy as np
 from hashlib import md5
 
 class WalkletWalker(RandomWalker):
+    """Defines the walklet walker of the walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+
+    """
+
     def __init__(self, depth, walks_per_graph):
         super(WalkletWalker, self).__init__(depth, walks_per_graph)
 
     def extract(self, graph, instances):
+         """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         canonical_walks = set()
         for instance in instances:
             walks = self.extract_random_walks(graph, Vertex(str(instance)))

--- a/rdf2vec/walkers/walklets.py
+++ b/rdf2vec/walkers/walklets.py
@@ -4,7 +4,7 @@ import numpy as np
 from hashlib import md5
 
 class WalkletWalker(RandomWalker):
-    """Defines the walklet walker of the walking strategy.
+    """Defines the walklet walking strategy.
 
     Attributes:
         depth (int): The depth per entity.
@@ -16,12 +16,8 @@ class WalkletWalker(RandomWalker):
         super(WalkletWalker, self).__init__(depth, walks_per_graph)
 
     def extract(self, graph, instances):
-         """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
@@ -30,7 +26,9 @@ class WalkletWalker(RandomWalker):
             instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         canonical_walks = set()

--- a/rdf2vec/walkers/weisfeiler_lehman.py
+++ b/rdf2vec/walkers/weisfeiler_lehman.py
@@ -10,6 +10,7 @@ class WeisfeilerLehmanWalker(RandomWalker):
     Attributes:
         depth (int): The depth per entity.
         walks_per_graph (float): The maximum number of walks per entity.
+
     """
 
     def __init__(self, depth, walks_per_graph, wl_iterations=4):

--- a/rdf2vec/walkers/weisfeiler_lehman.py
+++ b/rdf2vec/walkers/weisfeiler_lehman.py
@@ -5,7 +5,7 @@ from rdf2vec.graph import Vertex
 
 
 class WeisfeilerLehmanWalker(RandomWalker):
-    """Defines the Weisfeller-Lehman walking strategy.
+    """Defines the Weisfeler-Lehman walking strategy.
 
     Attributes:
         depth (int): The depth per entity.

--- a/rdf2vec/walkers/weisfeiler_lehman.py
+++ b/rdf2vec/walkers/weisfeiler_lehman.py
@@ -60,22 +60,19 @@ class WeisfeilerLehmanWalker(RandomWalker):
 
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
                 The graph from which the neighborhoods are extracted for the
                 provided instances.
-            instances (array-like): The instances to extract the knowledge
-                graph.
+            instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         self._weisfeiler_lehman(graph)

--- a/rdf2vec/walkers/weisfeiler_lehman.py
+++ b/rdf2vec/walkers/weisfeiler_lehman.py
@@ -28,7 +28,7 @@ class WeisfeilerLehmanWalker(RandomWalker):
         # return suffix
 
     def _weisfeiler_lehman(self, graph):
-        """Performs Weisfeiller-Lehman relabeling of the vertices.
+        """Performs Weisfeiler-Lehman relabeling of the vertices.
 
         Note:
             You can create a `graph.KnowledgeGraph` object from an

--- a/rdf2vec/walkers/weisfeiler_lehman.py
+++ b/rdf2vec/walkers/weisfeiler_lehman.py
@@ -5,6 +5,13 @@ from rdf2vec.graph import Vertex
 
 
 class WeisfeilerLehmanWalker(RandomWalker):
+    """Defines the Weisfeller-Lehman walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+    """
+
     def __init__(self, depth, walks_per_graph, wl_iterations=4):
         super(WeisfeilerLehmanWalker, self).__init__(depth, walks_per_graph)
         self.wl_iterations = wl_iterations
@@ -20,7 +27,18 @@ class WeisfeilerLehmanWalker(RandomWalker):
         # return suffix
 
     def _weisfeiler_lehman(self, graph):
-        """Perform Weisfeiler-Lehman relabeling of the vertices"""
+        """Performs Weisfeiller-Lehman relabeling of the vertices.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+
+        """
         self._label_map = defaultdict(dict)
         self._inv_label_map = defaultdict(dict)
 
@@ -41,6 +59,24 @@ class WeisfeilerLehmanWalker(RandomWalker):
 
 
     def extract(self, graph, instances):
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge
+                graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         self._weisfeiler_lehman(graph)
 
         canonical_walks = set()

--- a/rdf2vec/walkers/wildcard.py
+++ b/rdf2vec/walkers/wildcard.py
@@ -5,11 +5,35 @@ import itertools
 from hashlib import md5
 
 class WildcardWalker(RandomWalker):
+    """Defines the wild card of the walking strategy.
+
+    Attributes:
+        depth (int): The depth per entity.
+        walks_per_graph (float): The maximum number of walks per entity.
+    """
+
     def __init__(self, depth, walks_per_graph, wildcards=[1]):
         super(WildcardWalker, self).__init__(depth, walks_per_graph)
         self.wildcards = wildcards
 
     def extract(self, graph, instances):
+        """Extracts a knowledge graph and transform it into a 2D vector, based
+        on provided instances.
+
+        Note:
+            You can create a `graph.KnowledgeGraph` object from an
+            `rdflib.Graph` object by using a converter method.
+
+        Args:
+            graph (graph.KnowledgeGraph): The knowledge graph.
+                The graph from which the neighborhoods are extracted for the
+                provided instances.
+            instances (array-like): The instances to extract the knowledge graph.
+
+        Returns:
+            list: The 2D vector corresponding to the knowledge graph.
+
+        """
         canonical_walks = set()
         for instance in instances:
             walks = self.extract_random_walks(graph, Vertex(str(instance)))

--- a/rdf2vec/walkers/wildcard.py
+++ b/rdf2vec/walkers/wildcard.py
@@ -10,6 +10,7 @@ class WildcardWalker(RandomWalker):
     Attributes:
         depth (int): The depth per entity.
         walks_per_graph (float): The maximum number of walks per entity.
+
     """
 
     def __init__(self, depth, walks_per_graph, wildcards=[1]):

--- a/rdf2vec/walkers/wildcard.py
+++ b/rdf2vec/walkers/wildcard.py
@@ -5,7 +5,7 @@ import itertools
 from hashlib import md5
 
 class WildcardWalker(RandomWalker):
-    """Defines the wild card of the walking strategy.
+    """Defines the wild card walking strategy.
 
     Attributes:
         depth (int): The depth per entity.
@@ -18,22 +18,19 @@ class WildcardWalker(RandomWalker):
         self.wildcards = wildcards
 
     def extract(self, graph, instances):
-        """Extracts a knowledge graph and transform it into a 2D vector, based
-        on provided instances.
-
-        Note:
-            You can create a `graph.KnowledgeGraph` object from an
-            `rdflib.Graph` object by using a converter method.
+        """Extracts walks rooted at the provided instances which are then each
+        transformed into a numerical representation.
 
         Args:
             graph (graph.KnowledgeGraph): The knowledge graph.
                 The graph from which the neighborhoods are extracted for the
                 provided instances.
-            instances (array-like): The instances to extract the knowledge
-                graph.
+            instances (array-like): The instances to extract the knowledge graph.
 
         Returns:
-            list: The 2D vector corresponding to the knowledge graph.
+            list: The 2D matrix with its:
+                number of rows equal to the number of provided instances;
+                number of column equal to the embedding size.
 
         """
         canonical_walks = set()

--- a/rdf2vec/walkers/wildcard.py
+++ b/rdf2vec/walkers/wildcard.py
@@ -28,7 +28,8 @@ class WildcardWalker(RandomWalker):
             graph (graph.KnowledgeGraph): The knowledge graph.
                 The graph from which the neighborhoods are extracted for the
                 provided instances.
-            instances (array-like): The instances to extract the knowledge graph.
+            instances (array-like): The instances to extract the knowledge
+                graph.
 
         Returns:
             list: The 2D vector corresponding to the knowledge graph.


### PR DESCRIPTION
This pull request will use the [Google Style Python Docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html?highlight=google%20convention) convention. 

This convention has the advantage of being more readable, and can later be converted by the [Sphinx](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/index.html) document generator to generate the online documentation of `pyRDF2Vec` with [Read the Docs](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html).

**NOTE:** the documentation for some methods may be incorrect or incomplete.