### PR TITLE
major: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "pip"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This pull request ensures that we don't have to remember to `poetry update` and commit new versions of packages that `pyRDF2Vec` depends on, which can be tedious. To do so, I created the `dependabot.yml` file that will add a bot to the repository to automatically make Pull Requests and update the versions of packages on which `pyRDF2Vec` depends.

This default configuration is simplistic, every Monday (can be changed for every day/month) `dependabot` will make a Pull Request to update the versions of the internal packages. Another good thing is that the bot should also display a report of the different changes made in the releases of the internal packages used, so we don't have to go and check each repository ourselves.

@GillesVandewiele I invite you to look at the preferences in the [documentation](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates) if you want me to add/remove specific lines to `dependabot`. If you agree to merge this Pull Request, can you enable Dependabot security updates for this repository (if it's not yet done)? 

**SEE:** https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/#stop-using-vulnerable-dependencies-dependabot-alerts-and-security-updates