### PR TITLE
Rename the master branch to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ["develop", "main"]
   pull_request:
-    branches: ["main"]
+    branches: ["develop"]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   push:
-    branches: ["develop", "master"]
+    branches: ["develop", "main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 jobs:
   build:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,9 +56,9 @@ golden rules that you should know before you contribute to ``pyRDF2Vec``:
    to avoid unpleasant surprises.
 -  **Attach a short note to the pull request:** it would help us to better
    understand what you did.
--  **It's up to you how you handle updates to the master branch:** since we
-   squash on merge, whether you prefer to rebase on ``master`` or merge
-   ``master`` into your branch, do whatever is more comfortable for you.
+-  **It's up to you how you handle updates to the main branch:** since we
+   squash on merge, whether you prefer to rebase on ``main`` or merge
+   ``main`` into your branch, do whatever is more comfortable for you.
 
 
 Changelog
@@ -210,7 +210,7 @@ To achieve this, there are 5 points there are 5 points to follow:
     ]
 
 3. **Extend the** `Embedder
-   <https://github.com/IBCNServices/pyRDF2Vec/blob/master/pyrdf2vec/embedders/embedder.py>`__
+   <https://github.com/IBCNServices/pyRDF2Vec/blob/main/pyrdf2vec/embedders/embedder.py>`__
    **class** in your embedder's class and implement at least the ``fit`` and
    ``transform`` functions:
 
@@ -260,7 +260,7 @@ To achieve this, there are 5 points there are 5 points to follow:
 
 Create a ``tests/embedders/foo.py`` file and see `how the tests are done for
 Word2Vec
-<https://github.com/IBCNServices/pyRDF2Vec/blob/master/tests/embedders/test_word2vec.py>`__
+<https://github.com/IBCNServices/pyRDF2Vec/blob/main/tests/embedders/test_word2vec.py>`__
 as an example.
 
 Once this is done, run your tests:
@@ -313,7 +313,7 @@ adding an embedding technique:
     ]
 
 3. **Extend the** `Walker
-   <https://github.com/IBCNServices/pyRDF2Vec/blob/master/pyrdf2vec/walkers/walker.py>`__
+   <https://github.com/IBCNServices/pyRDF2Vec/blob/main/pyrdf2vec/walkers/walker.py>`__
    **class** in your walker's class and implement at least the ``_extract``
    function:
 
@@ -369,7 +369,7 @@ adding an embedding technique:
 
 Create a ``tests/walkers/foo.py`` file and see `how the tests are done for
 RandomWalker
-<https://github.com/IBCNServices/pyRDF2Vec/blob/master/tests/walkers/test_random.py>`__
+<https://github.com/IBCNServices/pyRDF2Vec/blob/main/tests/walkers/test_random.py>`__
 as an example.
 
 Once this is done, run your tests:
@@ -418,7 +418,7 @@ adding a walking strategy and a embedding technique:
     ]
 
 3. **Extend the** `Sampler
-   <https://github.com/IBCNServices/pyRDF2Vec/blob/master/pyrdf2vec/samplers/sampler.py>`__
+   <https://github.com/IBCNServices/pyRDF2Vec/blob/main/pyrdf2vec/samplers/sampler.py>`__
    **class** in your sampler's class and implement at least the ``fit`` and
    ``get_weight`` functions:
 
@@ -459,7 +459,7 @@ adding a walking strategy and a embedding technique:
 
 Create a ``tests/samplers/foo.py`` file and see `how the tests are done for
 UniformSampler
-<https://github.com/IBCNServices/pyRDF2Vec/blob/master/tests/samplers/uniform.py>`__
+<https://github.com/IBCNServices/pyRDF2Vec/blob/main/tests/samplers/uniform.py>`__
 as an example.
 
 Once this is done, run your tests:
@@ -489,7 +489,7 @@ illustrated:
 1. **Create your connector** (e.g., ``FooConnector``) in ``pyrdf2vec/connectors``.
 2. **Import your connector** in the ``pyrdf2vec/connector/__init__.py`` file.
 3. **Extend the** `Connector
-   <https://github.com/IBCNServices/pyRDF2Vec/blob/master/pyrdf2vec/connectors.py>`__
+   <https://github.com/IBCNServices/pyRDF2Vec/blob/main/pyrdf2vec/connectors.py>`__
    **class** in your connector's class and implement at least the ``fetch``
    function:
 
@@ -533,7 +533,7 @@ illustrated:
 
 Create a ``tests/connectors/foo.py`` file and see `how the tests are done for
 SPARQLConnector
-<https://github.com/IBCNServices/pyRDF2Vec/blob/master/pyrdf2vec/connectors.py>`__
+<https://github.com/IBCNServices/pyRDF2Vec/blob/main/pyrdf2vec/connectors.py>`__
 as an example.
 
 Once this is done, run your tests:
@@ -560,9 +560,9 @@ pyRDF2Vec <https://pyrdf2vec.readthedocs.io/en/latest/>`__ is hosted on
 `Read the Docs <https://readthedocs.org/>`__. To generate this online
 documentation, we use:
 
-- `Sphinx <https://www.sphinx-doc.org/en/master/>`__ as a Python documentation generator ;
+- `Sphinx <https://www.sphinx-doc.org/en/main/>`__ as a Python documentation generator ;
 -  `Google Style
-   docstrings <https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html>`__:
+   docstrings <https://www.sphinx-doc.org/en/main/usage/extensions/example_google.html>`__:
    as a docstring writing convention.
 - ``mypy``: as a optional static typing for Python.
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@
        <a href="https://pypi.org/project/pyrdf2vec">
            <img src="https://img.shields.io/pypi/dm/pyrdf2vec.svg?logo=pypi&color=1082C2" alt="Version">
        </a>
-       <a href="https://github.com/IBCNServices/pyRDF2Vec/blob/master/LICENSE">
+       <a href="https://github.com/IBCNServices/pyRDF2Vec/blob/main/LICENSE">
            <img src="https://img.shields.io/github/license/IBCNServices/pyRDF2vec" alt="License">
        </a>
    </p>
@@ -30,8 +30,8 @@
         <a href="https://pyrdf2vec.readthedocs.io/en/latest/?badge=latest">
            <img src="https://readthedocs.org/projects/pyrdf2vec/badge/?version=latest" alt="Documentation Status">
        </a>
-        <a href="https://codecov.io/gh/IBCNServices/pyRDF2Vec?branch=master">
-           <img src="https://codecov.io/gh/IBCNServices/pyRDF2Vec/coverage.svg?branch=master&precision=2" alt="Coverage Status">
+        <a href="https://codecov.io/gh/IBCNServices/pyRDF2Vec?branch=main">
+           <img src="https://codecov.io/gh/IBCNServices/pyRDF2Vec/coverage.svg?branch=main&precision=2" alt="Coverage Status">
        </a>
        <a href="https://github.com/psf/black">
            <img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black">
@@ -198,7 +198,7 @@ beforehand:
 2. **define a walking strategy**.
 
 For more elaborate examples, check the `examples
-<https://github.com/IBCNServices/pyRDF2Vec/blob/master/examples>`__ folder.
+<https://github.com/IBCNServices/pyRDF2Vec/blob/main/examples>`__ folder.
 
 If no sampling strategy is defined, ``UniformSampler`` is used. Similarly for
 the embedding techniques, ``Word2Vec`` is used by default.
@@ -436,7 +436,7 @@ Documentation
 
 For more information on how to use ``pyRDF2Vec``, `visit our online documentation
 <https://pyrdf2vec.readthedocs.io/en/latest/>`__ which is automatically updated
-with the latest version of the ``master`` branch.
+with the latest version of the ``main`` branch.
 
 From then on, you will be able to learn more about the use of the
 modules as well as their functions available to you.
@@ -456,7 +456,7 @@ The architecture of ``pyRDF2Vec`` makes it easy to create new extraction and
 sampling strategies, new embedding techniques. In order to better understand
 how you can help either through pull requests and/or issues, please take a look
 at the `CONTRIBUTING
-<https://github.com/IBCNServices/pyRDF2Vec/blob/master/CONTRIBUTING.rst>`__
+<https://github.com/IBCNServices/pyRDF2Vec/blob/main/CONTRIBUTING.rst>`__
 file.
 
 FAQ
@@ -530,4 +530,3 @@ citation:
       organization = {IDLab},
       keywords     = {Machine Learning (cs.LG), FOS: Computer and information sciences, FOS: Computer and information sciences}
     }
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,8 @@ Preview
            <a href="https://pyrdf2vec.readthedocs.io/en/latest/?badge=latest">
               <img src="https://readthedocs.org/projects/pyrdf2vec/badge/?version=latest" alt="Documentation Status">
           </a>
-           <a href="https://codecov.io/gh/IBCNServices/pyRDF2Vec?branch=master">
-              <img src="https://codecov.io/gh/IBCNServices/pyRDF2Vec/coverage.svg?branch=master&precision=2" alt="Coverage Status">
+           <a href="https://codecov.io/gh/IBCNServices/pyRDF2Vec?branch=main">
+              <img src="https://codecov.io/gh/IBCNServices/pyRDF2Vec/coverage.svg?branch=main&precision=2" alt="Coverage Status">
           </a>
           <a href="https://github.com/psf/black">
               <img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg">

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -4,7 +4,7 @@ License and Credits
 
 ``pyRDF2Vec`` is licensed under the ``MIT`` license.  The full license text
 can be also found in the `source code repository
-<https://github.com/IBCNServices/pyRDF2Vec/blob/master/LICENSE>`_.
+<https://github.com/IBCNServices/pyRDF2Vec/blob/main/LICENSE>`_.
 
 ``pyRDF2Vec`` is written and maintained by `Gilles Vandewiele
 <http://www.gillesvandewiele.com/>`_.


### PR DESCRIPTION
This brings more consistency with modern conventions (cf. [Guidance for changing the default branch name for GitHub repositories](https://github.com/github/renaming))